### PR TITLE
Fix: explicitly remove outline from showing in Firefox and Safari

### DIFF
--- a/src/libs/client/src/components/layouts/navigation-bar/book-search/book-search.tsx
+++ b/src/libs/client/src/components/layouts/navigation-bar/book-search/book-search.tsx
@@ -48,7 +48,7 @@ export default function BookSearch({ className }: ComponentProps<"div">) {
         <MagnifyingGlass />
         <input
           type="search"
-          className="w-full bg-inherit outline-0"
+          className="w-full bg-inherit outline-none focus:outline-none"
           placeholder="Enter a book or string..."
           onChange={handleOnChange}
           onKeyDown={handleOnEnterPress}


### PR DESCRIPTION
When focusing on the book search input element while displaying the website on Firefox, the outline is displayed when it should not be. I modified the outline styles to remove this behaviour.