### PR TITLE
fix: isbn book search bug where the correct book was not returned

### DIFF
--- a/src/libs/server/src/hono/routes/books.ts
+++ b/src/libs/server/src/hono/routes/books.ts
@@ -149,22 +149,14 @@ books.get(
   }),
   async (c) => {
     const { isbn } = c.req.valid("param");
+    console.log(isbn);
     if (!isbn) {
       const responseData: BadResponse = { success: false, error: "ISBN is required" };
       return c.json(responseData, 400);
     }
 
-    let book: Book[];
-
     const googleBooksService = new GoogleBooksService(c.env.GOOGLE_BOOKS_API_KEY);
-    book = await googleBooksService.getBookByISBN(isbn);
-
-    if (book.length === 0) {
-      book = (await googleBooksService.getBooksByAllParameters({ searchInput: { search: isbn }, paginationFilter: {} }))
-        .books;
-      const responseData: GoodResponse<Book[]> = { success: true, data: book };
-      return c.json(responseData);
-    }
+    const book = await googleBooksService.getBookByISBN(isbn);
 
     const responseData: GoodResponse<Book[]> = { success: true, data: book };
     return c.json(responseData);

--- a/src/libs/server/src/hono/routes/books.ts
+++ b/src/libs/server/src/hono/routes/books.ts
@@ -159,11 +159,13 @@ books.get(
 
     const googleBooksService = new GoogleBooksService(c.env.GOOGLE_BOOKS_API_KEY);
     book = await googleBooksService.getBookByISBN(isbn);
+    console.log("This is the first level of isbn search", book);
 
     if (book.length === 0) {
+      console.log("This is the second level of isbn search because the main ISBN search returned no books");
       const bookSearchResult = (
         await googleBooksService.getBooksByAllParameters({ searchInput: { isbn }, paginationFilter: {} })
-      ).books.find((book) => book.isbn10 || book.isbn13 === isbn);
+      ).books.find((book) => book.isbn10 === isbn || book.isbn13 === isbn);
 
       if (!bookSearchResult) {
         book = [];
@@ -173,9 +175,10 @@ books.get(
     }
 
     if (book.length === 0) {
+      console.log("This is the third level of isbn search because the second level of isbn search returned no books");
       const bookSearchResult = (
         await googleBooksService.getBooksByAllParameters({ searchInput: { search: isbn }, paginationFilter: {} })
-      ).books.find((book) => book.isbn10 || book.isbn13 === isbn);
+      ).books.find((book) => book.isbn10 === isbn || book.isbn13 === isbn);
 
       if (!bookSearchResult) {
         book = [];

--- a/src/libs/server/src/hono/routes/books.ts
+++ b/src/libs/server/src/hono/routes/books.ts
@@ -155,8 +155,34 @@ books.get(
       return c.json(responseData, 400);
     }
 
+    let book: Book[];
+
     const googleBooksService = new GoogleBooksService(c.env.GOOGLE_BOOKS_API_KEY);
-    const book = await googleBooksService.getBookByISBN(isbn);
+    book = await googleBooksService.getBookByISBN(isbn);
+
+    if (book.length === 0) {
+      const bookSearchResult = (
+        await googleBooksService.getBooksByAllParameters({ searchInput: { isbn }, paginationFilter: {} })
+      ).books.find((book) => book.isbn10 || book.isbn13 === isbn);
+
+      if (!bookSearchResult) {
+        book = [];
+      } else {
+        book = [bookSearchResult];
+      }
+    }
+
+    if (book.length === 0) {
+      const bookSearchResult = (
+        await googleBooksService.getBooksByAllParameters({ searchInput: { search: isbn }, paginationFilter: {} })
+      ).books.find((book) => book.isbn10 || book.isbn13 === isbn);
+
+      if (!bookSearchResult) {
+        book = [];
+      } else {
+        book = [bookSearchResult];
+      }
+    }
 
     const responseData: GoodResponse<Book[]> = { success: true, data: book };
     return c.json(responseData);

--- a/src/libs/server/src/services/google.service.ts
+++ b/src/libs/server/src/services/google.service.ts
@@ -55,7 +55,13 @@ export class GoogleBooksService {
   async getBookByISBN(isbn: string): Promise<Book[]> {
     const url = `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}&key=${this.apiKey}`;
     const books = (await this.fetchBooks(url)).books;
-    return books.length > 0 ? books : [];
+    const book = books.find((book) => book.isbn13 || book.isbn10 === isbn);
+
+    if (books.length === 0 || !book) {
+      return [];
+    }
+
+    return [book];
   }
 
   async getBooksByAllParameters({

--- a/src/libs/server/src/services/google.service.ts
+++ b/src/libs/server/src/services/google.service.ts
@@ -55,7 +55,7 @@ export class GoogleBooksService {
   async getBookByISBN(isbn: string): Promise<Book[]> {
     const url = `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}&key=${this.apiKey}`;
     const books = (await this.fetchBooks(url)).books;
-    const book = books.find((book) => book.isbn13 || book.isbn10 === isbn);
+    const book = books.find((book) => book.isbn13 === isbn || book.isbn10 === isbn);
 
     if (books.length === 0 || !book) {
       return [];


### PR DESCRIPTION
There was a bug in the endpoint for getting a book by ISBN. The ideal logic would be that the ISBN would be passed on in the endpoint URL, and if a book were found, it would return the JSON correctly. However, what was happening was that because one of the functions involved passing the search object with the ISBN as the 'search' value, it was returning a range of books that were not correct. Hopefully, this PR simplifies and corrects the previous issue.