### PR TITLE
Fix: bug where the search page was not rendering as expected

### DIFF
--- a/src/libs/client/src/components/modules/search-page/hooks.ts
+++ b/src/libs/client/src/components/modules/search-page/hooks.ts
@@ -92,9 +92,9 @@ export function useSearchPage(): SearchPageHookReturnType {
 
     if (searchParams.toString() !== searchParamsObject.toString()) {
       router.replace(`/search?${searchParamsObject.toString()}`);
+    } else {
+      setRun(true);
     }
-
-    setRun(true);
   }, [router, searchParams]);
 
   return {

--- a/src/libs/client/src/components/modules/search-page/search-page-query-component-wrapper.tsx
+++ b/src/libs/client/src/components/modules/search-page/search-page-query-component-wrapper.tsx
@@ -7,6 +7,13 @@ import { SearchPageQueryComponent } from "./search-page-query-component";
 export function SearchPageQueryComponentWrapper() {
   const searchParams = useSearchParams();
 
+  const searchParamsHasSearch = searchParams.has("search");
+  const searchParamsHasFilters = filterKeysArray.filter((val) => searchParams.has(val));
+
+  if (!searchParamsHasSearch && searchParamsHasFilters.length === 0) {
+    return <div>Please enter a search term or select a filter and click &quot;Submit&quot;</div>;
+  }
+
   const searchObject: SearchObjectType = {};
   const paginationObject: PaginationObjectType = {};
 

--- a/src/libs/client/src/components/modules/search-page/search-page.tsx
+++ b/src/libs/client/src/components/modules/search-page/search-page.tsx
@@ -15,13 +15,9 @@ import { Container } from "../../layouts/container";
 import { SearchPageQueryComponentWrapper } from "./search-page-query-component-wrapper";
 import { data } from "./data";
 import { SearchPageResultsLoadingSkeleton } from "./search-page-results-loading-skeleton";
-import { filterKeysArray } from "@/root/src/libs/shared/src/utils";
 
 export const SearchPage = function (): ReactElement {
   const { filters, allInputElementRefsMap, searchInputElement, router, searchParams, run, setRun } = useSearchPage();
-
-  const paramsHasSearch = searchParams.has("search");
-  const paramsHasFilters = filterKeysArray.filter((val) => searchParams.has(val));
 
   const handleOnSubmit = function (e: React.MouseEvent<HTMLButtonElement>) {
     e.preventDefault();
@@ -129,9 +125,7 @@ export const SearchPage = function (): ReactElement {
             Submit
           </Button>
         </form>
-        {run && !paramsHasSearch && paramsHasFilters.length === 0 ? (
-          <div>Please enter a search term or select a filter and click &quot;Submit&quot;</div>
-        ) : run ? (
+        {run ? (
           <Suspense fallback={<SearchPageResultsLoadingSkeleton />}>
             <SearchPageQueryComponentWrapper />
           </Suspense>


### PR DESCRIPTION
This PR was opened to fix a render bug in the Search page. For a brief moment, the message that is meant to be shown when there are no 'searchPrams' is shown when the page first loads. It seems this bug was due to a wrong ending in the 'useEffect' hook function. Now 'run' is only set to true if the original 'searchParams' string is not equal to the new 'searchParams' string. Else, the URL is changed to contain the new 'searchParams' object.