### PR TITLE
Refactor: Auth Signup to route handler

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
         "ignoreArrowShorthand": true
       }
     ],
-    "@typescript-eslint/no-unnecessary-condition": "off"
+    "@typescript-eslint/no-unnecessary-condition": "off",
+    "@typescript-eslint/only-throw-error": "off"
   }
 }

--- a/src/app/api/(auth)/signup/route.ts
+++ b/src/app/api/(auth)/signup/route.ts
@@ -2,14 +2,12 @@ import { CustomAPIError, fetchData } from "@/root/src/libs/client/src/utils";
 import { SanitizedUser } from "@/root/src/libs/shared/src/db/schema";
 import type { SignupInput } from "@/root/src/libs/shared/src/validators";
 import { type NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { HandlerResult } from "@/shared/types/form-state";
 import { SignupResult } from "@/shared/validators/auth";
 
 export async function POST(req: NextRequest): Promise<NextResponse<HandlerResult<SignupResult>>> {
   try {
     const signupInput = (await req.json()) as SignupInput;
-    console.log("signupInput", signupInput);
     const data = await fetchData<{ message: string; user: SanitizedUser }>(`${process.env.API_URL}/auth/signup`, {
       method: "POST",
       body: JSON.stringify(signupInput),
@@ -17,7 +15,6 @@ export async function POST(req: NextRequest): Promise<NextResponse<HandlerResult
         "Content-Type": "application/json",
       },
     });
-    console.log(cookies().getAll());
 
     return NextResponse.json({ formResult: { success: true, data } });
   } catch (e) {

--- a/src/app/api/(auth)/signup/route.ts
+++ b/src/app/api/(auth)/signup/route.ts
@@ -1,11 +1,12 @@
 import { CustomAPIError, fetchData } from "@/root/src/libs/client/src/utils";
 import { SanitizedUser } from "@/root/src/libs/shared/src/db/schema";
 import type { SignupInput } from "@/root/src/libs/shared/src/validators";
-import { FormResult } from "@/root/src/libs/shared/src/types";
 import { type NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { HandlerResult } from "@/shared/types/form-state";
+import { SignupResult } from "@/shared/validators/auth";
 
-export async function POST(req: NextRequest): Promise<NextResponse<FormResult>> {
+export async function POST(req: NextRequest): Promise<NextResponse<HandlerResult<SignupResult>>> {
   try {
     const signupInput = (await req.json()) as SignupInput;
     console.log("signupInput", signupInput);
@@ -18,7 +19,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<FormResult>> 
     });
     console.log(cookies().getAll());
 
-    return NextResponse.json({ formResult: { success: true, message: data.message } });
+    return NextResponse.json({ formResult: { success: true, data } });
   } catch (e) {
     if (e instanceof CustomAPIError) {
       return NextResponse.json(

--- a/src/app/api/(auth)/signup/route.ts
+++ b/src/app/api/(auth)/signup/route.ts
@@ -2,7 +2,7 @@ import { CustomAPIError, fetchData } from "@/root/src/libs/client/src/utils";
 import { SanitizedUser } from "@/root/src/libs/shared/src/db/schema";
 import type { SignupInput } from "@/root/src/libs/shared/src/validators";
 import { type NextRequest, NextResponse } from "next/server";
-import { HandlerResult } from "@/shared/types/form-state";
+import { HandlerResult } from "@/shared/types";
 import { SignupResult } from "@/shared/validators/auth";
 
 export async function POST(req: NextRequest): Promise<NextResponse<HandlerResult<SignupResult>>> {
@@ -16,11 +16,11 @@ export async function POST(req: NextRequest): Promise<NextResponse<HandlerResult
       },
     });
 
-    return NextResponse.json({ formResult: { success: true, data } });
+    return NextResponse.json({ handlerResult: { success: true, data } });
   } catch (e) {
     if (e instanceof CustomAPIError) {
       return NextResponse.json(
-        { formResult: { success: false, errors: e.errors } },
+        { handlerResult: { success: false, errors: e.errors } },
         {
           status: e.status,
         },
@@ -28,7 +28,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<HandlerResult
     }
 
     return NextResponse.json(
-      { formResult: { success: false, errors: ["Something went wrong. Please try again later."] } },
+      { handlerResult: { success: false, errors: ["Something went wrong. Please try again later."] } },
       {
         status: 500,
       },

--- a/src/app/api/(auth)/signup/route.ts
+++ b/src/app/api/(auth)/signup/route.ts
@@ -1,37 +1,58 @@
-import { CustomAPIError, fetchData } from "@/root/src/libs/client/src/utils";
-import { SanitizedUser } from "@/root/src/libs/shared/src/db/schema";
 import type { SignupInput } from "@/root/src/libs/shared/src/validators";
 import { type NextRequest, NextResponse } from "next/server";
-import { HandlerResult } from "@/shared/types";
+import { BadResponse, GoodResponse, HandlerResult } from "@/shared/types";
 import { SignupResult } from "@/shared/validators/auth";
 
 export async function POST(req: NextRequest): Promise<NextResponse<HandlerResult<SignupResult>>> {
+  let response = new NextResponse<HandlerResult<SignupResult>>();
+  let setCookie: string | null = null;
+  const signupInput = (await req.json()) as SignupInput;
   try {
-    const signupInput = (await req.json()) as SignupInput;
-    const data = await fetchData<{ message: string; user: SanitizedUser }>(`${process.env.API_URL}/auth/signup`, {
+    const externalResponse = await fetch(`${process.env.API_URL}/auth/signup`, {
       method: "POST",
       body: JSON.stringify(signupInput),
       headers: {
         "Content-Type": "application/json",
       },
+      credentials: "include",
     });
 
-    return NextResponse.json({ handlerResult: { success: true, data } });
-  } catch (e) {
-    if (e instanceof CustomAPIError) {
-      return NextResponse.json(
-        { handlerResult: { success: false, errors: e.errors } },
+    setCookie = externalResponse.headers.get("set-cookie");
+
+    if (!externalResponse.ok) {
+      const errorObj = (await externalResponse.json()) as BadResponse;
+
+      response = NextResponse.json(
+        { handlerResult: errorObj },
         {
-          status: e.status,
+          status: externalResponse.status,
         },
       );
+
+      if (setCookie) {
+        response.headers.set("set-cookie", setCookie);
+      }
+
+      return response;
     }
 
-    return NextResponse.json(
-      { handlerResult: { success: false, errors: ["Something went wrong. Please try again later."] } },
+    const data = (await externalResponse.json()) as GoodResponse<SignupResult>;
+
+    response = NextResponse.json({ handlerResult: data });
+
+    if (setCookie) {
+      response.headers.set("set-cookie", setCookie);
+    }
+
+    return response;
+  } catch (e) {
+    response = NextResponse.json(
+      { handlerResult: { success: false, errors: ["Something went wrong. Please try again."] } },
       {
         status: 500,
       },
     );
+
+    return response;
   }
 }

--- a/src/app/api/(auth)/signup/route.ts
+++ b/src/app/api/(auth)/signup/route.ts
@@ -1,0 +1,39 @@
+import { CustomAPIError, fetchData } from "@/root/src/libs/client/src/utils";
+import { SanitizedUser } from "@/root/src/libs/shared/src/db/schema";
+import type { SignupInput } from "@/root/src/libs/shared/src/validators";
+import { FormResult } from "@/root/src/libs/shared/src/types";
+import { type NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+export async function POST(req: NextRequest): Promise<NextResponse<FormResult>> {
+  try {
+    const signupInput = (await req.json()) as SignupInput;
+    console.log("signupInput", signupInput);
+    const data = await fetchData<{ message: string; user: SanitizedUser }>(`${process.env.API_URL}/auth/signup`, {
+      method: "POST",
+      body: JSON.stringify(signupInput),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    console.log(cookies().getAll());
+
+    return NextResponse.json({ formResult: { success: true, message: data.message } });
+  } catch (e) {
+    if (e instanceof CustomAPIError) {
+      return NextResponse.json(
+        { formResult: { success: false, errors: e.errors } },
+        {
+          status: e.status,
+        },
+      );
+    }
+
+    return NextResponse.json(
+      { formResult: { success: false, errors: ["Something went wrong. Please try again later."] } },
+      {
+        status: 500,
+      },
+    );
+  }
+}

--- a/src/libs/client/src/components/modules/auth/signup/signup-form.tsx
+++ b/src/libs/client/src/components/modules/auth/signup/signup-form.tsx
@@ -4,30 +4,27 @@ import React from "react";
 import { Label } from "@/client/components/ui/label";
 import { Input } from "@/client/components/ui/input";
 import { FormErrorListItem } from "@/client/components/ui/form-error-list-item";
-import { signupSchema, SignupFormState } from "@/root/src/libs/shared/src/validators";
+import { signupSchema, SignupFormState, SignupInput } from "@/root/src/libs/shared/src/validators";
 import { useRouter } from "next/navigation";
-import { FormResult } from "@/libs/shared/src/types";
-import { fetchData, CustomAPIError } from "@/client/utils";
+import { FieldError, FormResult } from "@/libs/shared/src/types";
 import { Check } from "@/client/components/ui/icons/check";
 import { SubmitButton } from "@/client/components/ui/submit-button";
-import { SanitizedUser } from "@/shared/db/schema";
 
 export function SignupForm() {
   const router = useRouter();
   const [signupFormState, setSignupFormState] = React.useState<SignupFormState>({
     fieldError: { userName: [], emailAddress: [], password: [] },
-    formResult: null,
   });
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
-  const updateSignupFormState = async function (event: React.FormEvent<HTMLFormElement>): Promise<SignupFormState> {
+  const updateSignupFormState = async function (event: React.FormEvent<HTMLFormElement>): Promise<FormResult> {
     const formData = new FormData(event.currentTarget);
     const signupObjRaw = Object.fromEntries(formData);
 
     const validation = signupSchema.safeParse(signupObjRaw);
 
     if (!validation.success) {
-      return {
+      const errorObj: FieldError<SignupInput> = {
         fieldError: {
           userName: validation.error.issues
             .filter((issue) => issue.path[0] === "userName")
@@ -39,73 +36,56 @@ export function SignupForm() {
             .filter((issue) => issue.path[0] === "password")
             .map((issue) => issue.message),
         },
-        formResult: null,
       };
+      throw errorObj;
     }
 
     const signupObj = validation.data;
 
-    try {
-      const data = await fetchData<{ message: string; user: SanitizedUser }>(
-        `${process.env.NEXT_PUBLIC_API_URL}/auth/signup`,
-        {
-          method: "POST",
-          body: JSON.stringify(signupObj),
-          headers: {
-            "Content-Type": "application/json",
-          },
-          credentials: "include",
-        },
-      );
+    const res = await fetch("/api/signup", {
+      method: "POST",
+      body: JSON.stringify(signupObj),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
 
-      return {
-        fieldError: { userName: [], emailAddress: [], password: [] },
-        formResult: { success: true, message: data.message },
-      };
-    } catch (e) {
-      if (e instanceof CustomAPIError) {
-        return {
-          fieldError: { userName: [], emailAddress: [], password: [] },
-          formResult: { success: false, errors: e.errors },
-        };
-      }
-
-      return {
-        fieldError: { userName: [], emailAddress: [], password: [] },
-        formResult: { success: false, errors: ["Something went wrong. Please try again later."] },
-      };
+    if (!res.ok) {
+      const errorObj = (await res.json()) as FormResult;
+      throw errorObj;
     }
+
+    const { formResult } = (await res.json()) as FormResult;
+    return { formResult };
   };
 
   const onSubmit = async function (e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setIsSubmitting(true);
-
-    const newFormState = await updateSignupFormState(e);
-    setSignupFormState(newFormState);
-
-    if (newFormState.formResult !== null) {
-      if (newFormState.formResult.success) {
-        router.push("/");
-      }
+    try {
+      const newFormResult = await updateSignupFormState(e);
+      setSignupFormState((prev) => ({ prev, ...newFormResult }));
+      setIsSubmitting(false);
+      router.push("/");
+    } catch (e) {
+      const newFormState = e as SignupFormState;
+      setSignupFormState((prev) => ({ prev, ...newFormState }));
+      setIsSubmitting(false);
     }
-    setIsSubmitting(false);
   };
 
   const FormResultMessage = function ({ formResult }: { formResult: FormResult }) {
-    if (formResult.success) {
+    if (formResult.formResult?.success) {
       return (
         <p className="flex items-center gap-x-0 text-success">
           <Check className="text-success" fill="#4ade80"></Check>
-          {formResult.message}
+          {formResult.formResult.message}
         </p>
       );
     } else {
       return (
         <ul style={{ listStyle: "disc", listStylePosition: "outside" }}>
-          {formResult.errors.map((error, i) => (
-            <FormErrorListItem key={i}>{error}</FormErrorListItem>
-          ))}
+          {formResult.formResult?.errors.map((error, i) => <FormErrorListItem key={i}>{error}</FormErrorListItem>)}
         </ul>
       );
     }
@@ -117,9 +97,9 @@ export function SignupForm() {
         <Label htmlFor="userName">Username:</Label>
         <Input id="userName" type="text" name="userName" />
         <ul style={{ listStyle: "disc", listStylePosition: "outside" }}>
-          {signupFormState.fieldError.userName.map((error, i) => (
-            <FormErrorListItem key={i}>{error}</FormErrorListItem>
-          ))}
+          {signupFormState.fieldError?.userName.map((error, i) => (
+              <FormErrorListItem key={i}>{error}</FormErrorListItem>
+            ))}
         </ul>
       </div>
 
@@ -127,7 +107,7 @@ export function SignupForm() {
         <Label htmlFor="emailAddress">Email address:</Label>
         <Input id="emailAddress" type="email" name="emailAddress" />
         <ul style={{ listStyle: "disc", listStylePosition: "outside" }}>
-          {signupFormState.fieldError.emailAddress.map((error, i) => (
+          {signupFormState.fieldError?.emailAddress.map((error, i) => (
             <FormErrorListItem key={i}>{error}</FormErrorListItem>
           ))}
         </ul>
@@ -137,7 +117,7 @@ export function SignupForm() {
         <Label htmlFor="password">Password:</Label>
         <Input id="password" type="password" name="password" />
         <ul style={{ listStyle: "disc", listStylePosition: "outside" }}>
-          {signupFormState.fieldError.password.map((error, i) => (
+          {signupFormState.fieldError?.password.map((error, i) => (
             <FormErrorListItem key={i}>{error}</FormErrorListItem>
           ))}
         </ul>
@@ -146,9 +126,7 @@ export function SignupForm() {
       <div>
         <SubmitButton isSubmitting={isSubmitting} defaultText={"Sign up"} submittingText={"Signing up..."} />
       </div>
-      {signupFormState.formResult !== null && (
-        <FormResultMessage formResult={signupFormState.formResult}></FormResultMessage>
-      )}
+      {signupFormState.formResult && <FormResultMessage formResult={signupFormState}></FormResultMessage>}
     </form>
   );
 }

--- a/src/libs/client/src/components/modules/auth/signup/signup-form.tsx
+++ b/src/libs/client/src/components/modules/auth/signup/signup-form.tsx
@@ -26,7 +26,7 @@ export function SignupForm() {
     const validation = signupSchema.safeParse(signupObjRaw);
 
     if (!validation.success) {
-      const errorObj: FieldError<SignupInput> = {
+      const fieldErrorObj: FieldError<SignupInput> = {
         fieldError: {
           userName: validation.error.issues
             .filter((issue) => issue.path[0] === "userName")
@@ -39,7 +39,7 @@ export function SignupForm() {
             .map((issue) => issue.message),
         },
       };
-      throw errorObj;
+      return fieldErrorObj;
     }
 
     const signupObj = validation.data;
@@ -50,12 +50,9 @@ export function SignupForm() {
       headers: {
         "Content-Type": "application/json",
       },
+      credentials: "include",
     });
     const result = (await res.json()) as HandlerResult<SignupResult>;
-
-    if (!res.ok) {
-      throw result;
-    }
 
     return result;
   };
@@ -63,15 +60,11 @@ export function SignupForm() {
   const onSubmit = async function (e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setIsSubmitting(true);
-    try {
-      const newFormState = await updateSignupFormState(e);
-      setSignupFormState(newFormState);
-      setIsSubmitting(false);
+    const newFormState = await updateSignupFormState(e);
+    setSignupFormState(newFormState);
+    setIsSubmitting(false);
+    if ("handlerResult" in newFormState && newFormState.handlerResult.success) {
       router.push("/");
-    } catch (e) {
-      const newFormState = e as SignupFormState;
-      setSignupFormState(newFormState);
-      setIsSubmitting(false);
     }
   };
 

--- a/src/libs/client/src/components/modules/auth/signup/signup-form.tsx
+++ b/src/libs/client/src/components/modules/auth/signup/signup-form.tsx
@@ -9,7 +9,7 @@ import { useRouter } from "next/navigation";
 import { FieldError } from "@/libs/shared/src/types";
 import { Check } from "@/client/components/ui/icons/check";
 import { SubmitButton } from "@/client/components/ui/submit-button";
-import { HandlerResult } from "@/shared/types/form-state";
+import { HandlerResult } from "@/shared/types";
 import { SignupResult } from "@/shared/validators/auth";
 
 export function SignupForm() {
@@ -64,8 +64,8 @@ export function SignupForm() {
     e.preventDefault();
     setIsSubmitting(true);
     try {
-      const newFormResult = await updateSignupFormState(e);
-      setSignupFormState(newFormResult);
+      const newFormState = await updateSignupFormState(e);
+      setSignupFormState(newFormState);
       setIsSubmitting(false);
       router.push("/");
     } catch (e) {
@@ -75,18 +75,18 @@ export function SignupForm() {
     }
   };
 
-  const FormResultMessage = function ({ formResult }: { formResult: HandlerResult<SignupResult> }) {
-    if (formResult.formResult.success) {
+  const HandlerResultMessage = function ({ handlerResult }: { handlerResult: HandlerResult<SignupResult> }) {
+    if (handlerResult.handlerResult.success) {
       return (
         <p className="flex items-center gap-x-0 text-success">
           <Check className="text-success" fill="#4ade80"></Check>
-          {formResult.formResult.data.message}
+          {handlerResult.handlerResult.data.message}
         </p>
       );
     } else {
       return (
         <ul style={{ listStyle: "disc", listStylePosition: "outside" }}>
-          {formResult.formResult.errors.map((error, i) => (
+          {handlerResult.handlerResult.errors.map((error, i) => (
             <FormErrorListItem key={i}>{error}</FormErrorListItem>
           ))}
         </ul>
@@ -132,7 +132,9 @@ export function SignupForm() {
       <div>
         <SubmitButton isSubmitting={isSubmitting} defaultText={"Sign up"} submittingText={"Signing up..."} />
       </div>
-      {"formResult" in signupFormState && <FormResultMessage formResult={signupFormState}></FormResultMessage>}
+      {"handlerResult" in signupFormState && (
+        <HandlerResultMessage handlerResult={signupFormState}></HandlerResultMessage>
+      )}
     </form>
   );
 }

--- a/src/libs/client/src/utils.ts
+++ b/src/libs/client/src/utils.ts
@@ -40,7 +40,7 @@ export class CustomAPIError extends Error {
 }
 
 export const fetchData = async function <T>(url: string, options?: RequestInit) {
-  const res = await fetch(url, { credentials: "include", ...options });
+  const res = await fetch(url, options);
 
   if (!res.ok) {
     const errorObj = (await res.json()) as BadResponse;

--- a/src/libs/server/src/hono/routes/auth.ts
+++ b/src/libs/server/src/hono/routes/auth.ts
@@ -13,6 +13,7 @@ import { setSessionCookie, deleteSessionCookie, getSessionCookieToken } from "@/
 import { encryptAuthSessionToken } from "@/server/auth/utils";
 import { cache } from "hono/cache";
 import { sanitizedUser } from "@/server/utils";
+import { SignupResult } from "@/shared/validators/auth";
 
 export const auth = new Hono<Environment>();
 
@@ -65,7 +66,7 @@ auth.post(
     const responseData = { user: sanitizedUser(newUser), message };
     console.log("responseData", responseData);
 
-    const data: GoodResponse<{ user: SanitizedUser; message: string }> = {
+    const data: GoodResponse<SignupResult> = {
       success: true,
       data: responseData,
     };

--- a/src/libs/server/src/hono/routes/auth.ts
+++ b/src/libs/server/src/hono/routes/auth.ts
@@ -63,8 +63,7 @@ auth.post(
 
     message = "Account successfully created!";
 
-    const responseData = { user: sanitizedUser(newUser), message };
-    console.log("responseData", responseData);
+    const responseData: SignupResult = { user: sanitizedUser(newUser), message };
 
     const data: GoodResponse<SignupResult> = {
       success: true,

--- a/src/libs/shared/src/types/form-state.ts
+++ b/src/libs/shared/src/types/form-state.ts
@@ -1,7 +1,9 @@
-export type FormState<T> = FieldError<T> & FormResult;
+import { BadResponse, GoodResponse } from "./response";
+
+export type FormState<T, P = unknown> = FieldError<T> | HandlerResult<P>;
 
 export type FieldError<T> = {
-  fieldError?: { [key in keyof T]: string[] };
+  fieldError: { [key in keyof T]: string[] };
 };
 
-export type FormResult = { formResult?: { success: false; errors: string[] } | { success: true; message: string } };
+export type HandlerResult<P> = { formResult: BadResponse | GoodResponse<P> }; // For the route handler specifically

--- a/src/libs/shared/src/types/form-state.ts
+++ b/src/libs/shared/src/types/form-state.ts
@@ -1,8 +1,7 @@
-export type FormState<T> = {
-  fieldError: {
-    [key in keyof T]: string[];
-  };
-  formResult: FormResult | null;
+export type FormState<T> = FieldError<T> & FormResult;
+
+export type FieldError<T> = {
+  fieldError?: { [key in keyof T]: string[] };
 };
 
-export type FormResult = { success: false; errors: string[] } | { success: true; message: string };
+export type FormResult = { formResult?: { success: false; errors: string[] } | { success: true; message: string } };

--- a/src/libs/shared/src/types/form-state.ts
+++ b/src/libs/shared/src/types/form-state.ts
@@ -1,9 +1,7 @@
-import { BadResponse, GoodResponse } from "./response";
+import { HandlerResult } from "./response";
 
 export type FormState<T, P = unknown> = FieldError<T> | HandlerResult<P>;
 
 export type FieldError<T> = {
   fieldError: { [key in keyof T]: string[] };
 };
-
-export type HandlerResult<P> = { formResult: BadResponse | GoodResponse<P> }; // For the route handler specifically

--- a/src/libs/shared/src/types/response.ts
+++ b/src/libs/shared/src/types/response.ts
@@ -4,3 +4,5 @@ export type GoodResponse<T = NonNullable<unknown>> = {
 };
 
 export type BadResponse = { success: false; errors: string[] };
+
+export type HandlerResult<P> = { handlerResult: BadResponse | GoodResponse<P> }; // For the route handler specifically

--- a/src/libs/shared/src/validators/auth.ts
+++ b/src/libs/shared/src/validators/auth.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { FormState } from "@/libs/shared/src/types";
+import { SanitizedUser } from "@/shared/db/schema";
 
 export const signupSchema = z.object({
   userName: z
@@ -23,4 +24,5 @@ export const signupSchema = z.object({
 });
 
 export type SignupInput = z.infer<typeof signupSchema>;
-export type SignupFormState = FormState<SignupInput>;
+export type SignupResult = { message: string; user: SanitizedUser };
+export type SignupFormState = FormState<SignupInput, SignupResult>;


### PR DESCRIPTION
Due to the NextJS server-first approach, I ran into a "bug" where I would send the cookie from my Hono Backend server to the client and it wouldn't send it back to the server. I realised that the Signup form was done on the client and so never went through the NextJS server. So when I was trying to use the getUser function, the request was not going through the browser but rather through the NextJS server. I have now refactored the auth signup to use a route handler.