### PR TITLE
Edit revalidate numbers in individual fetchServiceData calls

### DIFF
--- a/src/libs/server/src/services/google.service.ts
+++ b/src/libs/server/src/services/google.service.ts
@@ -11,7 +11,7 @@ export class GoogleBooksService {
   private async fetchBooks(url: string): Promise<{ books: Book[]; totalItems: number }> {
     try {
       console.log(url);
-      const data = await fetchServiceData<GoogleBooksResponse>(url, { next: { revalidate: 5184000 } });
+      const data = await fetchServiceData<GoogleBooksResponse>(url, { next: { revalidate: 172800 } });
       return { books: data.items.map((item) => this.mapBook(item)), totalItems: data.totalItems };
     } catch (error) {
       console.error("Problem getting books:", JSON.stringify(error, null, 2));

--- a/src/libs/server/src/services/ny-times.service.ts
+++ b/src/libs/server/src/services/ny-times.service.ts
@@ -8,7 +8,7 @@ export class NYTimesService {
     try {
       const data = await fetchServiceData<NYTimesBestSellersResponse>(
         `https://api.nytimes.com/svc/books/v3/lists/overview.json?api-key=${this.apiKey}`,
-        { next: { revalidate: 5184000 } },
+        { next: { revalidate: 604800 } },
       );
 
       const bestSellers = data.results.lists.map((list) => {

--- a/src/libs/server/src/services/open-library.service.ts
+++ b/src/libs/server/src/services/open-library.service.ts
@@ -6,7 +6,7 @@ export class OpenLibraryService {
     try {
       const data = await fetchServiceData<OpenLibraryResponse>(
         `https://openlibrary.org/api/volumes/brief/isbn/${isbn}.json`,
-        { next: { revalidate: 5184000 } },
+        { next: { revalidate: 172800 } },
       );
 
       const [recordsObj] = Object.values(data.records);


### PR DESCRIPTION
Change the next revalidate numbers to 2 days for OpenLibrary and Google Books calls and 7 days for NYT Best Sellers calls